### PR TITLE
Fix memory leak by removing unnecessary cleanup

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -83,38 +83,20 @@ module.exports = class Middleware extends EventEmitter {
     js() {
         return (req, res, next) => {
             res.type('javascript');
-            const bundler = this.writers.js.bundle();
-
-            bundler.on('error', cleanup);
-
-            const writeStream = bundler.pipe(res).on('error', cleanup);
-
-            function cleanup(e) {
-                res.write(`console.error(${JSON.stringify(e.stack)})`);
-                bundler.pause();
-                bundler.unpipe(writeStream);
-                writeStream.end();
-                next(e);
-            }
+            this.writers.js
+                .bundle()
+                .on('error', next)
+                .pipe(res);
         };
     }
 
     css() {
         return (req, res, next) => {
             res.type('css');
-            const bundler = this.writers.css.bundle();
-
-            bundler.on('error', cleanup);
-
-            const writeStream = bundler.pipe(res).on('error', cleanup);
-
-            function cleanup(e) {
-                res.write(`console.error(${JSON.stringify(e.stack)})`);
-                bundler.pause();
-                bundler.unpipe(writeStream);
-                writeStream.end();
-                next(e);
-            }
+            this.writers.css
+                .bundle()
+                .on('error', next)
+                .pipe(res);
         };
     }
 };


### PR DESCRIPTION
## Status
**READY**

## Description
Fixes memory leak caused by some funky cleanup code. res.end() was being called multiple times which seems to have been the source of the mem leak (unsure why it leaked exactly)
Unpipe code was also unnecessary.